### PR TITLE
fix: use latest nextflow and image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ WORKDIR /opt
   
 RUN git clone https://github.com/alumae/et-g2p-fst.git    
 
+RUN git clone -b 'v4.0' --single-branch --depth 1 https://github.com/snakers4/silero-vad.git
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,11 +107,6 @@ RUN cd /opt/est-asr-pipeline/punctuator-data/est_punct2 && \
 RUN cd /opt/est-asr-pipeline/bin && \
     ./extract_lid_features_kaldi.py foo fii  || echo "OK";
 
-# cache model for speech activity detection
-RUN cd /opt/est-asr-pipeline/bin && \
-    ./find_speech_segments.py foo fii  || echo "OK";
-
-
 RUN apt-get install -y procps
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,8 @@ RUN cd /opt/est-asr-pipeline/bin && \
 
 RUN apt-get install -y procps
 
-
+# cache model for speech activity detection
+RUN cd /opt/est-asr-pipeline/bin && \
+    ./find_speech_segments.py foo fii  || echo "OK";
 
 CMD ["/bin/bash"]    

--- a/bin/find_speech_segments.py
+++ b/bin/find_speech_segments.py
@@ -21,9 +21,9 @@ if __name__ == '__main__':
   
   USE_ONNX = False # change this to True if you want to test onnx model
   
-  model, utils = torch.hub.load(repo_or_dir='snakers4/silero-vad',
+  model, utils = torch.hub.load(repo_or_dir='/opt/silero-vad/',
+                                source='local',
                                 model='silero_vad',
-                                force_reload=False,
                                 onnx=USE_ONNX)
 
   (get_speech_timestamps,

--- a/bin/find_speech_segments.py
+++ b/bin/find_speech_segments.py
@@ -21,9 +21,9 @@ if __name__ == '__main__':
   
   USE_ONNX = False # change this to True if you want to test onnx model
   
-  model, utils = torch.hub.load(repo_or_dir='/opt/silero-vad/',
-                                source='local',
+  model, utils = torch.hub.load(repo_or_dir='snakers4/silero-vad',
                                 model='silero_vad',
+                                force_reload=False,
                                 onnx=USE_ONNX)
 
   (get_speech_timestamps,

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,4 +1,4 @@
-process.container = 'alumae/est-asr-pipeline:0.1.4'
+process.container = 'europe-north1-docker.pkg.dev/speech2text-218910/repo/est-asr-pipeline:1.0c'
 
 params {
 	acoustic_model = "cnn_tdnn_1d_online"
@@ -27,6 +27,10 @@ profiles {
         params.rootdir = "$projectDir"
         docker.enabled = false            
         
+    }
+
+    docker {
+	docker.enabled = true
     }
 
 }

--- a/transcribe.nf
+++ b/transcribe.nf
@@ -376,7 +376,7 @@ process punctuation {
 
 
 
-process output {
+process final_output {
     memory '500MB'
     
     publishDir "${out_dir}", mode: 'copy', overwrite: true
@@ -446,7 +446,7 @@ workflow {
     lattice2ctm( rnnlm_rescoring.out, mfcc.out.datadir_hires )
     to_json( lattice2ctm.out.segmented_ctm, lattice2ctm.out.with_compounds_ctm, speaker_id.out, diarization.out.show_uem_seg) \
       | punctuation
-    output( lattice2ctm.out.with_compounds_ctm, punctuation.out )
+    final_output( lattice2ctm.out.with_compounds_ctm, punctuation.out )
     empty_output( language_id.out.ifEmpty{ 'EMPTY' }, prepare_initial_data_dir.out.ifEmpty{ 'EMPTY' })
 }
 


### PR DESCRIPTION
In newer versions of nextflow `output` is a reserved keyword and it should be renamed in transcribe.nf.

Not sure if I picked a correct name for it, but this is to show that it works.

I also noticed that the latest image is not used in nextflow.config and the example command using `-profile docker` does not work because profile 'docker' is missing. I added a dummy one as I can't really test whether it works - I do not have a NVIDIA GPU which is required.

I've been using laptops(arm64 and amd64) without dedicated GPUs using the pre NVIDIA image and it works fine. For example 40min radio show takes 12-15minutes which is acceptable for my use case.

 Before merging probably the 'docker' profile needs updating and documentation regarding the fixing of nextflow to version 22 also needs an update. 
 
 But before this it should be tested by someone who has a NVIDIA GPU to test on.
 
 Due to these open questions I'm opening the PR as a draft.